### PR TITLE
Improve the travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,23 @@
 language: php
 
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 php:
   - 5.4
   - 5.5
   - 5.6
   - hhvm
+  
+install:
+  - composer install
 
 before_script:
-  - composer install --dev
+  - if [ "$TRAVIS_PHP_VERSION" = "hhvm" -o "$TRAVIS_PHP_VERSION" = "hhvm-nightly" ]; then rm phpspec.yml; fi
 
-script: sh -c 'if [ "$TRAVIS_PHP_VERSION" = "hhvm" -o "$TRAVIS_PHP_VERSION" = "hhvm-nightly" ]; then rm phpspec.yml && vendor/bin/phpspec run; else vendor/bin/phpspec run; fi;'
+script: vendor/bin/phpspec run
 
 after_script: sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" -a "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then vendor/bin/coveralls -v; fi;'


### PR DESCRIPTION
- switch to the container-based infrastructure
- enable the cache for composer downloads between builds
- make the script command more readable by removing the phpspec.yml file during before_script for HHVM
