### PR TITLE
OVH SDK v2 + Symfony3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         }
     ],
     "require": {
+        "php": ">=5.5",
         "symfony/dependency-injection" : "~2.3|~3.0",
         "symfony/config" : "~2.3|~3.0",
         "symfony/http-kernel": "~2.3|~3.0",

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
         }
     ],
     "require": {
-        "symfony/dependency-injection" : "~2.3",
-        "symfony/config" : "~2.3",
-        "symfony/http-kernel": "~2.3",
-        "ovh/ovh": "~1.1"
+        "symfony/dependency-injection" : "~2.3|~3.0",
+        "symfony/config" : "~2.3|~3.0",
+        "symfony/http-kernel": "~2.3|~3.0",
+        "ovh/ovh": "~2.0"
     },
     "autoload": {
         "psr-4": { "CoopTilleuls\\OvhBundle\\": "" }


### PR DESCRIPTION
Hello,

I wanted to plug this bundle to an existing Symfony 2.8 project using Guzzle 6+.
Unfortunately the OVH SDK v1 was using Guzzle 3+.

I upgraded to OVH SDK v2, which also uses Guzzle 6+.
I also updated composer.json to allow Symfony 3 projects to use this bundle.

NB: This may lead to hard BC breaks, since I never used the OVH v1 and don't know the consequences.
However, sending a SMS was a piece of cake, since I followed the original example in the README.md.
If you merge this PR, moving to a new major version is recommended.

Have a nice day,
Ben
