### PR TITLE
Symfony 4 compatiblity

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,7 +12,7 @@
             <argument>%coop_tilleuls_ovh.consumer_key%</argument>
         </service>
 
-        <service id="ovh" alias="coop_tilleuls_ovh.api" />
+        <service id="ovh" alias="coop_tilleuls_ovh.api" public="true" />
     </services>
 
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,6 +13,7 @@
         </service>
 
         <service id="ovh" alias="coop_tilleuls_ovh.api" public="true" />
+        <service id="Ovh\Api" alias="coop_tilleuls_ovh.api" />
     </services>
 
 </container>

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     ],
     "require": {
         "php": ">=5.5",
-        "symfony/dependency-injection" : "~2.3|~3.0",
-        "symfony/config" : "~2.3|~3.0",
-        "symfony/http-kernel": "~2.3|~3.0",
+        "symfony/dependency-injection" : "~2.3|~3.0|~4.0",
+        "symfony/config" : "~2.3|~3.0|~4.0",
+        "symfony/http-kernel": "~2.3|~3.0|~4.0",
         "ovh/ovh": "~2.0"
     },
     "autoload": {

--- a/spec/CoopTilleuls/OvhBundle/DependencyInjection/CoopTilleulsOvhExtensionSpec.php
+++ b/spec/CoopTilleuls/OvhBundle/DependencyInjection/CoopTilleulsOvhExtensionSpec.php
@@ -44,6 +44,7 @@ class CoopTilleulsOvhExtensionSpec extends ObjectBehavior
         $container->hasExtension('http://symfony.com/schema/dic/services')->shouldBeCalled();
         $container->setDefinition('coop_tilleuls_ovh.api', Argument::type('Symfony\Component\DependencyInjection\Definition'))->shouldBeCalled();
         $container->setAlias('ovh', Argument::type('Symfony\Component\DependencyInjection\Alias'))->shouldBeCalled();
+        $container->setAlias('Ovh\Api', Argument::type('Symfony\Component\DependencyInjection\Alias'))->shouldBeCalled();
 
         $configs = array(
             array(


### PR DESCRIPTION
Hello @dunglas & co,

Happy new year! :tada:

Can you please tag a new release? Currently, to use `ovh/ovh ~2.0` I must rely on `tilleuls/ovh-bundle ^1.0@dev` which gives me goosebumps each time I need to `composer update` :grin:

Thanks,
Ben

_Edit: My bad, didn't notice the 1.0.1 release last year - anyway, we'll need a new tag for SF 4.0_ :octocat: